### PR TITLE
Remove "Delete Originals" feature

### DIFF
--- a/src-tauri/src/compression.rs
+++ b/src-tauri/src/compression.rs
@@ -74,8 +74,6 @@ pub struct CompressionRecord {
     pub final_format: String,
     pub quality: u8,
     pub timestamp: u64,
-    #[serde(default)]
-    pub original_deleted: bool,
 }
 
 // ---------------------------------------------------------------------------

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -28,7 +28,6 @@ pub fn run() {
             commands::get_quality,
             commands::get_compression_history,
             commands::clear_compression_history,
-            commands::delete_original_images,
             commands::recompress,
             commands::compress_files,
             commands::get_watched_folders,

--- a/src-tauri/src/processor.rs
+++ b/src-tauri/src/processor.rs
@@ -130,7 +130,6 @@ pub fn process_file(
             final_format: format.to_string(),
             quality: current_quality,
             timestamp,
-            original_deleted: false,
         };
 
         // Log it

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,7 +22,7 @@ function App() {
     recompressed,
     handleRecompress,
     handleClearHistory,
-    handleDeleteOriginals,
+
     handleQualityChange,
     handleManualCompress,
   } = useCompressionEvents();
@@ -91,15 +91,7 @@ function App() {
             >
               Clear History
             </Button>
-            <Button
-              variant="destructive-outline"
-              size="sm"
-              className="w-full"
-              onClick={handleDeleteOriginals}
-              disabled={history.length === 0}
-            >
-              Delete Originals
-            </Button>
+
           </div>
         </div>
 

--- a/src/components/history-list.tsx
+++ b/src/components/history-list.tsx
@@ -53,7 +53,6 @@ export function HistoryList({
             <div className="grid grid-cols-[repeat(auto-fill,minmax(220px,1fr))] gap-2">
               {group.items.map(({ record, index }) => {
                 const cannotRecompress =
-                  record.original_deleted ||
                   recompressed.has(record.timestamp) ||
                   record.quality >= 100;
                 return (

--- a/src/hooks/use-compression-events.ts
+++ b/src/hooks/use-compression-events.ts
@@ -36,7 +36,6 @@ export function useCompressionEvents() {
           final_format: "",
           quality: 0,
           timestamp,
-          original_deleted: false,
           status: "processing"
         };
         return [...prev, newRecord];
@@ -73,7 +72,6 @@ export function useCompressionEvents() {
           final_format: "",
           quality: 0,
           timestamp: event.payload.timestamp,
-          original_deleted: false,
           status: "failed"
         };
         return [...prev, newRecord];
@@ -129,23 +127,6 @@ export function useCompressionEvents() {
     }
   }, []);
 
-  const handleDeleteOriginals = useCallback(async () => {
-    try {
-      const deleted = await invoke<number>("delete_original_images");
-      setHistory((prev) => prev.map((r) => ({ ...r, original_deleted: true })));
-      toastManager.add({
-        title: "Originals deleted",
-        description: `${deleted} original image${deleted === 1 ? "" : "s"} deleted.`,
-        type: "info",
-      });
-    } catch (e) {
-      toastManager.add({
-        title: "Failed to delete originals",
-        description: String(e),
-        type: "error",
-      });
-    }
-  }, []);
 
   const qualityTimer = useRef<ReturnType<typeof setTimeout>>(null);
   const handleQualityChange = useCallback(
@@ -178,7 +159,6 @@ export function useCompressionEvents() {
     recompressed,
     handleRecompress,
     handleClearHistory,
-    handleDeleteOriginals,
     handleQualityChange,
     handleManualCompress,
   };

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -7,7 +7,6 @@ export interface CompressionRecord {
   final_format: string;
   quality: number;
   timestamp: number;
-  original_deleted: boolean;
   status?: "processing" | "completed" | "failed";
 }
 


### PR DESCRIPTION
This change completely removes the "Delete Originals" feature from the application. It involves removing UI elements, frontend hooks, backend commands, and cleaning up the `CompressionRecord` data structure to remove the `original_deleted` field. The "Recompress" button logic has also been updated accordingly.

---
*PR created automatically by Jules for task [9774341056527199516](https://jules.google.com/task/9774341056527199516) started by @bittere*